### PR TITLE
Change JDK Base Image

### DIFF
--- a/jdk11-datadog-agent/Dockerfile
+++ b/jdk11-datadog-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-jre-slim-buster
+FROM eclipse-temurin:11.0.20.1_1-jdk-jammy
 
 ### Datadog agent config
 ENV DD_TRACE_ENABLED="false"
@@ -8,7 +8,7 @@ ARG DD_VERSION=0.110.0
 WORKDIR /opt/java-app/
 
 RUN  apt-get update \
-  && apt-get install --no-install-recommends -y wget=1.20.1-1.1 fontconfig=2.13.1-2 \
+  && apt-get install --no-install-recommends -y wget=1.21.2-2ubuntu1 fontconfig=2.13.1-4.2ubuntu5 \
   && wget -O dd-java-agent.jar \
     ${DD_REPO_BASE_URL}/v${DD_VERSION}/dd-java-agent-${DD_VERSION}.jar \
   && apt-get remove --purge -y wget \
@@ -16,4 +16,4 @@ RUN  apt-get update \
 
 ENV JAVA_OPTS="-javaagent:/opt/java-app/dd-java-agent.jar"
 
-LABEL io.buildpacks.stack.id=io.buildpacks.stacks.bionic
+LABEL io.buildpacks.stack.id=io.buildpacks.stacks.jammy


### PR DESCRIPTION
## Why?
The OpenJDK official docker image has been deprecated since [2022, Jun 9](https://github.com/docker-library/openjdk/issues/505). I'm changing the image to use the [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin) ones so we can keep receiving security updates on our images:
![image](https://github.com/Cobliteam/docker-images/assets/32147132/24d8cb19-75cf-46dc-b0f2-8c48d803fd90)
![image](https://github.com/Cobliteam/docker-images/assets/32147132/58c67720-d2a5-4e25-8a01-b543099f8b85)

## Changes:
- Update the image from OpenJDK to Eclipse-Temurin; the version was updated from 11.0.16 to 11.0.20.
- Update the Paketo to use the Ubuntu Jammy Base.

## Advantages:
The [Adoptium Foundation](https://adoptium.net/) publishes the docker images for more ISAs, which gives us and any user of these images more flexibility regarding hardware to run its projects.
